### PR TITLE
added AMD OpenCL include files

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -69,6 +69,7 @@ endif
 ifeq ($(OSNAME), Linux)
 LINUX = Yes
 CFLAGS += -I/usr/include/nvidia-current
+CFLAGS += -I/opt/AMDAPP/include
 ifeq ($(WORDSIZE), 32)
 CFLAGS += -O3 -fPIC -m32 -DWORDSIZE=32
 endif


### PR DESCRIPTION
When I tried to build Wings, I couldn't build cl, because it couldn't find the AMD OpenCL header files on my Ubuntu 12.10 box.

Because I didn't want to mess up too much with my base system (add links for example), I just modified the `c_src/Makefile` by adding the "official AMD OpenGL include directory" `/opt/AMDAPP/include` to the `CFLAGS` used on Linux.
