### PR TITLE
Fix fetching wrong parameter in ecl_set_kernel_arg_size (typo)

### DIFF
--- a/c_src/cl_nif.c
+++ b/c_src/cl_nif.c
@@ -4960,7 +4960,7 @@ static ERL_NIF_TERM ecl_set_kernel_arg_size(ErlNifEnv* env, int argc,
 	return enif_make_badarg(env);
     if (!enif_get_uint(env, argv[1], &arg_index))
 	return enif_make_badarg(env);
-    if (!ecl_get_sizet(env, argv[1], &arg_size))
+    if (!ecl_get_sizet(env, argv[2], &arg_size))
 	return enif_make_badarg(env);
 
     err = clSetKernelArg(o_kernel->obj.kernel,


### PR DESCRIPTION
As a result, size was ignored.